### PR TITLE
Parse missed PCI devices

### DIFF
--- a/lkddb/linux/browse_sources.py
+++ b/lkddb/linux/browse_sources.py
@@ -182,7 +182,8 @@ def parse_struct(scanner, fields, line, dep, filename, ret=False):
     nparam = 0
     for param in line:
         param = param.replace("\n", " ").strip()
-        if not param:
+        param = param.replace("\t", " ").strip()
+        if param == '':
             continue
         elif param[0] == ".":
             m = field_init_re.match(param)
@@ -197,11 +198,13 @@ def parse_struct(scanner, fields, line, dep, filename, ret=False):
                     raise lkddb.ParserError("in parse_line(): %s, %s, %s" % (filename, line, param))
             res[field] = value
         else:
+            if nparam >= len(fields):
+                break
             try:
                 res[fields[nparam]] = param
             except IndexError:
-                logger.exception("Index error: %s, %s, %s, %s" %
-                                 (scanner.name, fields, line, filename))
+                logger.exception("Index error: %s, %s, %s, %s, %s" %
+                                 (scanner.name, nparam, fields, line, filename))
                 return {}
         nparam += 1
     if res:

--- a/lkddb/linux/scanners.py
+++ b/lkddb/linux/scanners.py
@@ -160,7 +160,7 @@ def extract_value(field, dictionary):
                 return eval(val[val.find("=")+1:])
             else:
                 logger.error("error in extract_value: %s, %s --- '%s'" % (field, sorted(dictionary.items()), val))
-                assert False, "error in extract_value, 1: %s, %s --- '%s'" % (field, sorted(dictionary.items()), val)
+                return 0
         except NameError:
             logger.exception("error in extract_value: expected number in field %s from %s" %
                              (field, dictionary))


### PR DESCRIPTION
This is a fix for https://gitlab.com/cateee/lkddb/-/issues/1

Example of missed PCI device is pci:8086-06f0:

```
]$ grep -nR 06F0 linux-5.13/drivers/net/wireless/intel/iwlwifi
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:478:   {IWL_PCI_DEVICE(0x06F0, PCI_ANY_ID, iwl_qu_trans_cfg)},
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:569:   IWL_DEV_INFO(0x06F0, 0x0070, iwl_ax201_cfg_quz_hr, NULL),
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:570:   IWL_DEV_INFO(0x06F0, 0x0074, iwl_ax201_cfg_quz_hr, NULL),
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:571:   IWL_DEV_INFO(0x06F0, 0x0078, iwl_ax201_cfg_quz_hr, NULL),
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:572:   IWL_DEV_INFO(0x06F0, 0x007C, iwl_ax201_cfg_quz_hr, NULL),
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:573:   IWL_DEV_INFO(0x06F0, 0x0310, iwl_ax201_cfg_quz_hr, NULL),
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:574:   IWL_DEV_INFO(0x06F0, 0x1651, iwl_ax1650s_cfg_quz_hr, NULL),
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:575:   IWL_DEV_INFO(0x06F0, 0x1652, iwl_ax1650i_cfg_quz_hr, NULL),
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:576:   IWL_DEV_INFO(0x06F0, 0x2074, iwl_ax201_cfg_quz_hr, NULL),
linux-5.13/drivers/net/wireless/intel/iwlwifi/pcie/drv.c:577:   IWL_DEV_INFO(0x06F0, 0x4070, iwl_ax201_cfg_quz_hr, NULL),

```